### PR TITLE
Add HKR actors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,57 +1,18 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
 *.py[cod]
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-bin/
-build/
-develop-eggs/
-dist/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
+# Packages
 *.egg
+*.egg-info
 
 # Installer logs
 pip-log.txt
-pip-delete-this-directory.txt
 
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
-
-# Django stuff:
+*~
+*.swp
+*.swo
 *.log
-*.pot
-
-# Sphinx documentation
-docs/_build/
-
-logs
-
-LOG_*.txt
+*.log*.gz
+.venv
+*.pythonrc.py
+TODO
+db.sqlite3

--- a/fritzhome/actor.py
+++ b/fritzhome/actor.py
@@ -12,93 +12,28 @@ class Actor(object):
     You usally don't create that class yourself, use FritzBox.get_actors
     instead.
     """
+    def __init__(self, device_xml):
+        self.actor_id = device_xml.attrib['identifier']
+        self.device_id = device_xml.attrib['id']
+        self.name = device_xml.find('name').text
+        self.fwversion = device_xml.attrib['fwversion']
+        self.productname = device_xml.attrib['productname']
+        self.manufacturer = device_xml.attrib['manufacturer']
 
-    def __init__(self, fritzbox, device):
-        self.box = fritzbox
-
-        self.actor_id = device.attrib['identifier']
-        self.device_id = device.attrib['id']
-        self.name = device.find('name').text
-        self.fwversion = device.attrib['fwversion']
-        self.productname = device.attrib['productname']
-        self.manufacturer = device.attrib['manufacturer']
-        self.functionbitmask = int(device.attrib['functionbitmask'])
-
+        self.functionbitmask = int(device_xml.attrib['functionbitmask'])
+        self.has_hkr = self.functionbitmask & (1 << 6) > 0
         self.has_powermeter = self.functionbitmask & (1 << 7) > 0
         self.has_temperature = self.functionbitmask & (1 << 8) > 0
         self.has_switch = self.functionbitmask & (1 << 9) > 0
+        self.hast_dect_repeater = self.functionbitmask & (1 << 10) > 0
 
         self.temperature = 0.0
         if self.has_temperature:
-            if device.find("temperature").find("celsius").text is not None:
-                self.temperature = int(device.find("temperature").find("celsius").text) / 10
+            if device_xml.find("temperature").find("celsius").text is not None:
+                self.temperature = float(device_xml.find("temperature").find("celsius").text) / 10.0
             else:
                 logger.warn("Actor " + self.name + " seems offline. Returning None as temperature.")
                 self.temperature=None
 
-    def switch_on(self):
-        """
-        Set the power switch to ON.
-        """
-        return self.box.set_switch_on(self.actor_id)
-
-    def switch_off(self):
-        """
-        Set the power switch to OFF.
-        """
-        return self.box.set_switch_off(self.actor_id)
-
-    def get_state(self):
-        """
-        Get the current switch state.
-        """
-        return bool(
-            int(
-                self.box.homeautoswitch("getswitchstate", self.actor_id)
-            )
-        )
-
-    def get_present(self):
-        """
-        Check if the registered actor is currently present (reachable).
-        """
-        return bool(
-            self.box.homeautoswitch("getswitchpresent", self.actor_id)
-        )
-
-    def get_power(self):
-        """
-        Returns the current power usage in milliWatts.
-        Attention: Returns None if the value can't be queried or is unknown.
-        """
-        value = self.box.homeautoswitch("getswitchpower", self.actor_id)
-        return int(value) if value.isdigit() else None
-
-    def get_energy(self):
-        """
-        Returns the consumed energy since the start of the statistics in Wh.
-        Attention: Returns None if the value can't be queried or is unknown.
-        """
-        value = self.box.homeautoswitch("getswitchenergy", self.actor_id)
-        return int(value) if value.isdigit() else None
-
-    def get_temperature(self):
-        """
-        Returns the current environment temperature.
-        Attention: Returns None if the value can't be queried or is unknown.
-        """
-        #raise NotImplementedError("This should work according to the AVM docs, but don't...")
-        value = self.box.homeautoswitch("gettemperature", self.actor_id)
-        if value.isdigit():
-            return float(value)/10
-        else:
-            return None
-
-    def get_consumption(self, timerange="10"):
-        """
-        Return the energy report for the device.
-        """
-        return self.box.get_consumption(self.device_id, timerange)
-
     def __repr__(self):
-        return u"<Actor {}>".format(self.name)
+        return u'<Actor {}>'.format(repr(self.name))

--- a/fritzhome/fritz.py
+++ b/fritzhome/fritz.py
@@ -127,10 +127,6 @@ class FritzBox(object):
             return val.split(',')
         return []
 
-    def get_switch_actors(self):
-        """ Get information all switch actors """
-        return filter(lambda a: a.actor_id, self.get_actors())
-
     def set_switch_on(self, actor):
         """Switch the power of a actor ON"""
         return self._homeautoswitch('setswitchon', actor.actor_id)
@@ -206,12 +202,20 @@ class FritzBox(object):
         c_val = c_from_hkr_temperature(val)
         return c_val
 
-    def set_hkr_soll(self, actor, temperature):
+    def set_hkr_tsoll(self, actor, temperature):
         new_hkr_temp = c_to_hkr_temperature(temperature)
         val = self._homeautoswitch('sethkrtsoll', actor.actor_id, new_hkr_temp)
         return val
 
     # Helpers / "own" methods
+    def get_switch_actors(self):
+        """ Get all switch actors """
+        return filter(lambda a: a.has_switch, self.get_actors())
+
+    def get_hkr_actors(self):
+        ''' Get all HKR actors'''
+        return filter(lambda a: a.has_hkr, self.get_actors())
+
     def get_actor_by_ain(self, ain):
         """
         Return a actor identified by it's ain or return None

--- a/fritzhome/utils.py
+++ b/fritzhome/utils.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+def c_from_hkr_temperature(val):
+    '''Temperatur-Wert in 0,5 °C
+    Wertebereich: 16 – 56, 8°C bis 28°C
+    16 <= 8°C, 17 = 8,5°C...... 56 >= 28°C
+    254 = ON , 253 = OFF
+    '''
+    val = int(val)
+    assert val in range(16, 57) + [253, 254]
+
+    if val == 253:
+        return False
+    elif val == 254:
+        return True
+    else:
+        return val / 2.0
+
+def c_to_hkr_temperature(val):
+    val = int(round(val * 2))
+    assert val in range(16, 57)
+    return val


### PR DESCRIPTION
Maybe you want to pull something over but I've changed the API and core pars a lot because I don't like the idea of copying the FritzBox instance into all actor instances. Because of that I've moved all "actor-methods" into the FritzBox class to be called with the actor as argument - like:

```py
from fritzhome.fritz import FritzBox
fb = FritzBox('127.0.0.1', 'user', 'password')
fb.login()
actors = fb.get_hkr_actors()
value = fb.get_hkr_tsoll(actors[0])
```